### PR TITLE
small cleanups

### DIFF
--- a/rustlox/Cargo.lock
+++ b/rustlox/Cargo.lock
@@ -3,5 +3,134 @@
 version = 3
 
 [[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rustlox"
 version = "0.1.0"
+dependencies = [
+ "num_enum",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+
+[[package]]
+name = "winnow"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+dependencies = [
+ "memchr",
+]

--- a/rustlox/Cargo.toml
+++ b/rustlox/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num_enum = "0.6.1"

--- a/rustlox/src/chunk.rs
+++ b/rustlox/src/chunk.rs
@@ -2,36 +2,19 @@
 
 use crate::value::ValueArray;
 use crate::value::write_value_array;
+use num_enum::TryFromPrimitive;
+use num_enum::IntoPrimitive;
 
 #[repr(u8)]
-#[derive(Debug)]
+#[derive(Debug, TryFromPrimitive, IntoPrimitive)]
 pub enum OpCode {
-    OpConstant = 0,
-    OpReturn = 1,
-    OpNegate = 2,
-    OpAdd = 3,
-    OpSubtract = 4,
-    OpMultiply = 5,
-    OpDivide = 6,
-}
-
-impl OpCode {
-    pub fn to_u8(self) -> u8 {
-        self as u8
-    }
-    
-    pub fn from_u8(byte: u8) -> Option<OpCode> {
-        match byte {
-            0 => Some(OpCode::OpConstant),
-            1 => Some(OpCode::OpReturn),
-            2 => Some(OpCode::OpNegate),
-            3 => Some(OpCode::OpAdd),
-            4 => Some(OpCode::OpSubtract),
-            5 => Some(OpCode::OpMultiply),
-            6 => Some(OpCode::OpDivide),
-            _ => None,
-        }
-    }
+    Constant = 0,
+    Return = 1,
+    Negate = 2,
+    Add = 3,
+    Subtract = 4,
+    Multiply = 5,
+    Divide = 6,
 }
     
 #[derive(Debug, Default)]

--- a/rustlox/src/compiler.rs
+++ b/rustlox/src/compiler.rs
@@ -12,7 +12,7 @@ pub fn compile(source: String) {
         } else {
             print!("   | ");
         }
-        println!("{:2} '{}'", token.token_type as u8, token.text);
+        println!("{:2} '{}'", token.token_type as u8, token.text());
         if token.token_type == TokenType::EOF || token.token_type == TokenType::Error {
             break;
         }

--- a/rustlox/src/debug.rs
+++ b/rustlox/src/debug.rs
@@ -27,26 +27,26 @@ pub fn disassemble_instruction(chunk: &Chunk, offset: usize) -> usize {
     }
     
     let instruction = chunk.code[offset];
-    match OpCode::from_u8(instruction) {
-        Some(OpCode::OpReturn) => {
+    match OpCode::try_from(instruction) {
+        Ok(OpCode::Return) => {
             return simple_instruction("OP_RETURN", offset)
         }
-        Some(OpCode::OpConstant) => {
+        Ok(OpCode::Constant) => {
             return constant_instruction("OP_CONSTANT", chunk, offset)
         }
-        Some(OpCode::OpNegate) => {
+        Ok(OpCode::Negate) => {
             return simple_instruction("OP_NEGATE", offset)
         }
-        Some(OpCode::OpAdd) => {
+        Ok(OpCode::Add) => {
             return simple_instruction("OP_ADD", offset)
         }
-        Some(OpCode::OpSubtract) => {
+        Ok(OpCode::Subtract) => {
             return simple_instruction("OP_SUBTRACT", offset)
         }
-        Some(OpCode::OpMultiply) => {
+        Ok(OpCode::Multiply) => {
             return simple_instruction("OP_MULTIPLY", offset)
         }
-        Some(OpCode::OpDivide) => {
+        Ok(OpCode::Divide) => {
             return simple_instruction("OP_DIVIDE", offset)
         }
         _ => {

--- a/rustlox/src/vm.rs
+++ b/rustlox/src/vm.rs
@@ -67,41 +67,41 @@ impl VM<'_> {
             }
             
             let instruction = self.read_byte();
-            match OpCode::from_u8(instruction) {
-                Some(OpCode::OpReturn) => {
+            match OpCode::try_from(instruction) {
+                Ok(OpCode::Return) => {
                     print_value(self.pop());
                     println!();
                     return InterpretResult::Ok;
                 }
-                Some(OpCode::OpConstant) => {
+                Ok(OpCode::Constant) => {
                     let constant = self.read_constant();
                     self.push(constant);
                 }
-                Some(OpCode::OpNegate) => {
+                Ok(OpCode::Negate) => {
                     let val = -self.pop();
                     self.push(val);
                 }
-                Some(OpCode::OpAdd) => {
+                Ok(OpCode::Add) => {
                     let b = self.pop();
                     let a = self.pop();
                     self.push(a + b);
                 }
-                Some(OpCode::OpSubtract) => {
+                Ok(OpCode::Subtract) => {
                     let b = self.pop();
                     let a = self.pop();
                     self.push(a - b);
                 }
-                Some(OpCode::OpMultiply) => {
+                Ok(OpCode::Multiply) => {
                     let b = self.pop();
                     let a = self.pop();
                     self.push(a * b);
                 }
-                Some(OpCode::OpDivide) => {
+                Ok(OpCode::Divide) => {
                     let b = self.pop();
                     let a = self.pop();
                     self.push(a / b);
                 }
-                None => {
+                _ => {
                     println!("Unknown opcode {}", instruction);
                 return InterpretResult::RuntimeError;
                 }


### PR DESCRIPTION
- use traits for enum conversion
- use unsafe pointers into source code instead of borrowing